### PR TITLE
Fix Autologging in ModuleIORev and ModuleIOThrifty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,9 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    def akitJson = new groovy.json.JsonSlurper().parseText(new File(projectDir.getAbsolutePath() + "/vendordeps/AdvantageKit.json").text)
+    annotationProcessor "org.littletonrobotics.akit:akit-autolog:$akitJson.version"
 }
 
 test {

--- a/src/main/java/org/jmhsrobotics/frc2026/subsystems/drive/swerve/ModuleRev.java
+++ b/src/main/java/org/jmhsrobotics/frc2026/subsystems/drive/swerve/ModuleRev.java
@@ -19,6 +19,7 @@ import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.Alert.AlertType;
 import org.jmhsrobotics.frc2026.subsystems.drive.DriveConstants.revConstants;
+// import org.jmhsrobotics.frc2026.subsystems.drive.swerve.ModuleIO.ModuleIOInputs;
 import org.littletonrobotics.junction.Logger;
 
 public class ModuleRev {

--- a/src/main/java/org/jmhsrobotics/frc2026/subsystems/drive/swerve/ModuleThrifty.java
+++ b/src/main/java/org/jmhsrobotics/frc2026/subsystems/drive/swerve/ModuleThrifty.java
@@ -21,6 +21,8 @@ import edu.wpi.first.wpilibj.Alert.AlertType;
 import org.jmhsrobotics.frc2026.subsystems.drive.DriveConstants.thriftyConstants;
 import org.littletonrobotics.junction.Logger;
 
+// import org.jmhsrobotics.frc2026.subsystems.drive.swerve.ModuleIO.ModuleIOInputs;
+
 // import frc.robot.subsystems.drive.ModuleIOInputsAutoLogged;
 
 public class ModuleThrifty {


### PR DESCRIPTION
Added dependency required for the ModuleIOInputsAutoLogger class to be created after compiling. Un-commented Logger.processInputs() method in both ModuleIRev.java and ModulelThrifty.java
closes #24 