### PR TITLE
Fix AutoLogging in Vision.java

### DIFF
--- a/src/main/java/org/jmhsrobotics/frc2026/subsystems/vision/Vision.java
+++ b/src/main/java/org/jmhsrobotics/frc2026/subsystems/vision/Vision.java
@@ -27,14 +27,12 @@ import java.util.LinkedList;
 import java.util.List;
 import org.jmhsrobotics.frc2026.subsystems.vision.VisionIO.PoseObservationType;
 import org.jmhsrobotics.frc2026.subsystems.vision.VisionIO.TagPose;
-import org.jmhsrobotics.frc2026.subsystems.vision.VisionIO.VisionIOInputs;
 import org.littletonrobotics.junction.Logger;
 
 public class Vision extends SubsystemBase {
   private final VisionConsumer consumer;
   private final VisionIO[] io;
-  // TODO: Fix vision autologging
-  private final VisionIOInputs[] inputs;
+  private final VisionIOInputsAutoLogged[] inputs;
   private final Alert[] disconnectedAlerts;
 
   public Vision(VisionConsumer consumer, VisionIO... io) {
@@ -42,10 +40,9 @@ public class Vision extends SubsystemBase {
     this.io = io;
 
     // Initialize inputs
-    // TODO : Switch VisionIOInputs back to VisionIOInputsAutoLogged when autologging is fixed
-    this.inputs = new VisionIOInputs[io.length];
+    this.inputs = new VisionIOInputsAutoLogged[io.length];
     for (int i = 0; i < inputs.length; i++) {
-      inputs[i] = new VisionIOInputs();
+      inputs[i] = new VisionIOInputsAutoLogged();
     }
 
     // Initialize disconnected alerts
@@ -70,8 +67,7 @@ public class Vision extends SubsystemBase {
   public void periodic() {
     for (int i = 0; i < io.length; i++) {
       io[i].updateInputs(inputs[i]);
-      // TODO : Uncommment and reimplement process inputs when auotlogging is fixed
-      // Logger.processInputs("Vision/Camera" + Integer.toString(i), inputs[i]);
+      Logger.processInputs("Vision/Camera" + Integer.toString(i), inputs[i]);
     }
 
     // Initialize logging values


### PR DESCRIPTION
Previous issue (#24) addressed this issue indirectly via the added dependency for both the ModuleIOInputsAutoLogger class  and VisionIOInputsAutoLogged class to be created after compiling. Un-commented Logger.processInputs() method in Vision.java and changed mentions of VisionIOInputs to VisionIOInputsAutoLogged.
closes #48  