### PR TITLE
Fixed RPM control Not working

### DIFF
--- a/src/main/java/org/jmhsrobotics/frc2026/commands/ShooterSpinup.java
+++ b/src/main/java/org/jmhsrobotics/frc2026/commands/ShooterSpinup.java
@@ -23,7 +23,7 @@ public class ShooterSpinup extends Command {
   @Override
   public void execute() {
     // if (goalRPM > 0) {
-    //   this.shooter.setRPM(goalRPM);
+    this.shooter.setRPM(goalRPM);
     // } else {
     //   this.shooter.stop(); // Do not use Power to Spindown flywheels
     // }

--- a/src/main/java/org/jmhsrobotics/frc2026/subsystems/shooter/Shooter.java
+++ b/src/main/java/org/jmhsrobotics/frc2026/subsystems/shooter/Shooter.java
@@ -13,7 +13,7 @@ public class Shooter extends SubsystemBase {
   private ShooterIO shooterIO;
   private ShooterIOInputsAutoLogged shooterInputs = new ShooterIOInputsAutoLogged();
 
-  private PIDController rpmController = new PIDController(0, 0, 0);
+  private PIDController rpmController = new PIDController(0.08, 0, 0.005);
 
   private Timer accelerationTimer = new Timer();
 
@@ -39,7 +39,8 @@ public class Shooter extends SubsystemBase {
       // calculate PID output
       double centiVeloctiyRPM = shooterInputs.velocityRPM / 100.0;
       double centiGoalSpeedRPM = this.goalSpeedRPM / 100.0;
-      double pidControllerOutput = this.rpmController.calculate(centiVeloctiyRPM);
+      double pidControllerOutput =
+          this.rpmController.calculate(centiVeloctiyRPM, centiGoalSpeedRPM);
       double clampedOutput =
           MathUtil.clamp(pidControllerOutput, -maxPercentOutput, maxPercentOutput);
 


### PR DESCRIPTION
RPM control got commented out for tuning. We probably should allow this to be configured over network tables so we dont forget to re-enable the shooter.